### PR TITLE
Fixed missing HOSTTOOLS

### DIFF
--- a/classes/custom-kernel-logo.bbclass
+++ b/classes/custom-kernel-logo.bbclass
@@ -1,4 +1,3 @@
-HOSTTOOLS += "pngtopnm ppmquant pnmnoraw"
 
 KERNEL_LOGO_PNG ?= "custom_logo.png"
 SRC_URI_append = " file://${KERNEL_LOGO_PNG}"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -21,3 +21,5 @@ BBFILES_DYNAMIC += " \
     raspberrypi:${LAYERDIR}/dynamic-layers/raspberrypi/*/*/*.bbappend \
     raspberrypi:${LAYERDIR}/dynamic-layers/raspberrypi/*/*/*.bb \
 "
+
+HOSTTOOLS += "pngtopnm ppmquant pnmnoraw"


### PR DESCRIPTION
HOSTTOOLS was declared in custom-kernel-logo.bbclass but not readed during the parsing. Moved definition in conf/layer.conf.